### PR TITLE
FIX: upload a csv with empty lines

### DIFF
--- a/src/ui/components/watchlist/CreateWatchlist.vue
+++ b/src/ui/components/watchlist/CreateWatchlist.vue
@@ -113,6 +113,7 @@ export default Vue.extend({
         if (this.selectedFile != null) {
           parse(this.selectedFile, {
             header: true,
+            skipEmptyLines: true,
             error: this.handleError,
             complete: this.handleComplete,
           });


### PR DESCRIPTION
User can now upload CSV with empty lines. 

Empty lines will be ignored.

Usually files are saved with a new line at the end, so this will allow users to upload files without the struggle of editors adding new line at the end of a file.