### PR TITLE
fix(google login): only show error alert when is an error

### DIFF
--- a/src/ui/pages/GoogleOAuth2.vue
+++ b/src/ui/pages/GoogleOAuth2.vue
@@ -1,11 +1,15 @@
 <template>
-  <v-container v-if="loading" fill-height>
-    <v-row justify="center" align="center" align-content="center">
-      <v-progress-circular :size="300" indeterminate></v-progress-circular>
-    </v-row>
-    <v-row justify="center"><h3>Logging in...</h3></v-row>
-  </v-container>
-  <v-alert v-else color="red">Could not login. {{ error }}</v-alert>
+  <v-div>
+    <v-container v-if="loading" fill-height>
+      <v-row justify="center" align="center" align-content="center">
+        <v-progress-circular :size="300" indeterminate></v-progress-circular>
+      </v-row>
+      <v-row justify="center"><h3>Logging in...</h3></v-row>
+    </v-container>
+    <v-alert v-if="error != null" color="red"
+      >Could not login. {{ error }}</v-alert
+    >
+  </v-div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Bug fixed:
- When you login with your google account doesn't show an alert that indicates: "Could not login". 
- Only show that message when occurs an error.
